### PR TITLE
Handle no config_file with clean abort message, implement init command

### DIFF
--- a/lib/pairhost.rb
+++ b/lib/pairhost.rb
@@ -2,10 +2,20 @@ require "pairhost/version"
 require 'fog'
 require 'thor'
 require 'yaml'
+require 'fileutils'
 
 module Pairhost
+  def self.config_file
+    @config_file ||= File.expand_path('~/.pairhost/config.yml')
+  end
+
   def self.config
-    @config ||= YAML.load(File.open(File.expand_path('~/.pairhost/config.yml')))
+    @config ||= begin
+      unless File.exists? config_file
+        abort "No pairhost config found. First run 'pairhost init'."
+      end
+      YAML.load_file config_file
+    end
   end
 
   def self.instance_id
@@ -16,7 +26,7 @@ module Pairhost
     return @connection if @connection
 
     Fog.credentials = Fog.credentials.merge(
-      :private_key_path => config['private_key_path'], 
+      :private_key_path => config['private_key_path'],
     )
 
     @connection = Fog::Compute.new(
@@ -134,7 +144,7 @@ module Pairhost
       Pairhost.connection.servers.each do |server|
         puts server.tags['Name']
         puts server.inspect
-        puts 
+        puts
         puts
       end
     end
@@ -148,11 +158,12 @@ module Pairhost
 
     desc "init", "Setup your ~/.pairhost directory with default config"
     def init
-      
+      FileUtils.mkdir_p File.dirname(Pairhost.config_file)
+      FileUtils.cp(File.dirname(__FILE__) + '/../config.example.yml', Pairhost.config_file)
     end
 
-    private 
-    
+    private
+
     def display_status(server)
       puts "#{server.id}: #{server.tags['Name']}"
       puts "State: #{server.state}"


### PR DESCRIPTION
When using pairhost without a config, you get:

``` sh
$ pairhost list
/Users/me/.rip/active/lib/pairhost.rb:8:in `initialize': No such file or directory - /Users/me/.pairhost/config.yml (Errno::ENOENT)
        from /Users/me/.rip/active/lib/pairhost.rb:8:in `open'
        from /Users/me/.rip/active/lib/pairhost.rb:8:in `config'
        from /Users/me/.rip/active/lib/pairhost.rb:19:in `connection'
        from /Users/me/.rip/active/lib/pairhost.rb:134:in `list'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
        from /Users/me/.rip/active/bin/pairhost:6:in `<main>'
```

I added an abort message and implemented init so it results in:

``` sh
$ pairhost list
No pairhost config found. First run 'pairhost init'.
$ pairhost init
# ready to rock
```

```
```
