### PR TITLE
clean error message for status if no pairhost instance exists

### DIFF
--- a/lib/pairhost.rb
+++ b/lib/pairhost.rb
@@ -19,7 +19,13 @@ module Pairhost
   end
 
   def self.instance_id
-    @instance_id ||= File.read(File.expand_path('~/.pairhost/instance')).chomp
+    @instance_id ||= begin
+      file = File.expand_path('~/.pairhost/instance')
+      unless File.exists?(file)
+        abort "No pairhost instance found. Please create or attach to one."
+      end
+      File.read(file).chomp
+    end
   end
 
   def self.connection
@@ -38,7 +44,7 @@ module Pairhost
 
   def self.create(name)
     server_options = {
-      "tags" => {"Name" => name, 
+      "tags" => {"Name" => name,
                  "Created-By-Pairhost-Gem" => VERSION},
       "image_id" => config['ami_id'],
       "flavor_id" => config['flavor_id'],


### PR DESCRIPTION
Currently I see this if I have no instance:

``` sh
$ pairhost status
/Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pairhost-0.0.2/lib/pairhost.rb:22:in `read': No such file or directory - /Users/me/.pairhost/instance (Errno::ENOENT)
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pairhost-0.0.2/lib/pairhost.rb:22:in `instance_id'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pairhost-0.0.2/lib/pairhost.rb:74:in `fetch'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pairhost-0.0.2/lib/pairhost.rb:88:in `status'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pairhost-0.0.2/bin/pairhost:6:in `<top (required)>'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/bin/pairhost:23:in `load'
        from /Users/me/Developer/.rbenv/versions/1.9.3-p194/bin/pairhost:23:in `<main>'
```
