### PR TITLE
Update config.yml example to include access key before secret

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,6 +1,6 @@
 provider: 'AWS'
-aws_secret_access_key: 'YOUR_SECRET_ACCESS_KEY'
 aws_access_key_id: 'YOUR_SECRET_ACCESS_KEY_ID'
+aws_secret_access_key: 'YOUR_SECRET_ACCESS_KEY'
 
 ami_id: 'SOME-AMI'
 flavor_id: 'm1.large'


### PR DESCRIPTION
Swapping access and secret keys seems to be a common mistake that displays a rather cryptic error message
